### PR TITLE
🐛 Git - Fix alias 're-author'

### DIFF
--- a/workspaces/init/symlinks/git/.gitconfig
+++ b/workspaces/init/symlinks/git/.gitconfig
@@ -33,7 +33,7 @@
 	last = log -n 1
 	sha = rev-parse --short HEAD
 	graph = log --oneline --decorate --graph
-	re-author = "!CDATE=$(git show -s --date=iso --format=%cd @); GIT_COMMITTER_DATE=$CDATE GIT_AUTHOR_DATE=$CDATE git commit --amend --reset-author"
+	re-author = "!GIT_AUTHOR_DATE=$(git show -s --format=%ad @) git commit --amend --reset-author"
 	unpushed = log --branches --not --remotes --no-walk --decorate --oneline
 	noblame = "!f() { DEST=$(git config blame.ignoreRevsFile); if [[ -n $DEST ]]; then [[ -e $DEST ]] && [[ -n $(tail -n 1 $DEST) ]] && echo >> $DEST; git show -s --format=\"# %s%n%H%n\" $1 >> $DEST; fi }; f"
 	ignorelast = "!FILE=$(git config blame.ignoreRevsFile); git noblame && [[ -e $FILE ]] && git add $FILE && git commit -m \"Exclude $(git sha) from annotations - $(basename $(git branch --show-current))\""


### PR DESCRIPTION
This allows me to change the author name of a commit (for example, when I accidentally use my work email on a personal project), while retaining the original author date, and adding/updating the committer date.

Previously this was retaining the committer date instead, and also overwriting the author date with that, which is not what I want.